### PR TITLE
Set AWS region in deployment

### DIFF
--- a/deploy/development/deployment.tpl.yml
+++ b/deploy/development/deployment.tpl.yml
@@ -34,7 +34,9 @@ spec:
           securityContext:
             runAsUser: 1000
           env:
-            - name: S3_BUCKET_NAME
+            - name: AWS_REGION
+              value: eu-west-2
+            - name: AWS_S3_BUCKET
               valueFrom:
                 secretKeyRef:
                   name: s3-bucket-output

--- a/deploy/production/deployment.tpl.yml
+++ b/deploy/production/deployment.tpl.yml
@@ -34,7 +34,9 @@ spec:
           securityContext:
             runAsUser: 1000
           env:
-            - name: S3_BUCKET_NAME
+            - name: AWS_REGION
+              value: eu-west-2
+            - name: AWS_S3_BUCKET
               valueFrom:
                 secretKeyRef:
                   name: s3-bucket-output


### PR DESCRIPTION
Fixes a bug where S3Utils doesn't have the AWS region or bucket name, when deployed to Cloud Platform.